### PR TITLE
Update index.html.ejs

### DIFF
--- a/views/index.html.ejs
+++ b/views/index.html.ejs
@@ -14,7 +14,7 @@
     <% if (environment === 'production') { %>
     <script type="module" src="<%= manifest['src/main.js'].file %>"></script>
     <% } else { %>
-    <script type="module" src="http://localhost:5173/@vite"></script>
+    <script type="module" src="http://localhost:5173/@vite/client"></script>
     <script type="module" src="http://localhost:5173/src/main.js"></script>
     <% } %>
   </body>


### PR DESCRIPTION
CHANGE - load the HMR client - June 2023

Hello I was using your guide on [codeminer](https://blog.codeminer42.com/making-a-full-stack-app-with-vue-vite-and-express-that-supports-hot-reload/)

I had some trouble with the HMR client and recieved the following message:
> Loading module from “http://localhost:5173/@vite” was blocked because of a disallowed MIME type (“”).

The documentation on the [vite documentation](https://vitejs.dev/guide/backend-integration.html) indicates that the path to the HMR client has changed from `@vite` to`@vite/client`.

This is just an update ;-)

Thanks for your work.